### PR TITLE
Fix supplier name extraction

### DIFF
--- a/parse_product.py
+++ b/parse_product.py
@@ -155,12 +155,19 @@ def parse_suppliers(soup: BeautifulSoup) -> List[Supplier]:
         )
 
     # Additional supplier links found in compact info blocks
-    for link in soup.select('.product-company-info__name'):
+    for container in soup.select('.product-company-info__name'):
+        anchor = container.select_one('a.aui-link')
+        if anchor:
+            name = anchor.get_text(strip=True)
+            href = anchor.get('href')
+        else:
+            name = container.get_text(strip=True)
+            href = container.get('href')
         suppliers.append(
             Supplier(
                 dealer_id=None,
-                supplier_name=link.get_text(strip=True),
-                supplier_url=link.get('href'),
+                supplier_name=name,
+                supplier_url=href,
                 supplier_tel=None,
                 supplier_address=None,
                 supplier_description=None,


### PR DESCRIPTION
## Summary
- fix scraping fallback for supplier blocks by grabbing the anchor tag

## Testing
- `python parse_product.py https://nsk.pulscen.ru/products/vstraivayemy_kompyuter_na_din_reyku_np_6111_l2_j6412_4g_ssd512g_271899908 | jq '.suppliers'`


------
https://chatgpt.com/codex/tasks/task_e_688426f5bba88329a30e9d5801165def