### PR TITLE
Add product listing links parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,26 @@ python parse_categories.py https://nsk.pulscen.ru/price/computer -v
 ```
 
 Скрипт вернёт JSON-массив с названиями и ссылками на найденные подкатегории.
+
+### Сбор ссылок на товары
+
+Для получения всех ссылок на товары из выбранной подкатегории используйте
+скрипт `parse_product_links.py`:
+
+```bash
+python parse_product_links.py https://nsk.pulscen.ru/price/1901-nastolnye-kompjutery -v
+```
+
+Скрипт обходит все страницы подкатегории, учитывая пагинацию, и выводит
+JSON-массив с названием и URL каждого найденного товара.
+
+### Полный сбор товаров
+
+Чтобы собрать все товары из родительской категории, сохранить их в MongoDB и JSON‑файл, запустите `parse_all_products.py`:
+
+```bash
+python parse_all_products.py https://nsk.pulscen.ru/price/computer -v -o products.json
+```
+
+По умолчанию данные сохраняются в базу `pulscen` на `mongodb://localhost:27017` и в файл `products.json`.
+

--- a/parse_all_products.py
+++ b/parse_all_products.py
@@ -1,0 +1,85 @@
+import argparse
+import asyncio
+import json
+import logging
+
+from motor.motor_asyncio import AsyncIOMotorClient
+
+import parse_categories
+import parse_product_links
+import parse_product
+
+
+async def gather_product_links(category_url: str, concurrency: int = 5) -> list[str]:
+    """Collect product URLs from all subcategories of the given category."""
+    subcats = await parse_categories.parse(category_url)
+    logging.info("Found %s subcategories", len(subcats))
+
+    sem = asyncio.Semaphore(concurrency)
+    all_links: list[str] = []
+
+    async def collect(sub: dict) -> None:
+        url = sub["url"]
+        async with sem:
+            links = await parse_product_links.parse(url)
+            all_links.extend(link["url"] for link in links)
+            logging.info("%s links collected from %s", len(links), url)
+
+    await asyncio.gather(*(collect(sc) for sc in subcats))
+    return all_links
+
+
+async def gather_products(db, urls: list[str], concurrency: int = 10) -> list[dict]:
+    """Parse product pages and store them in MongoDB."""
+    sem = asyncio.Semaphore(concurrency)
+    results: list[dict] = []
+
+    async def parse_and_store(url: str) -> None:
+        async with sem:
+            try:
+                product = await parse_product.parse(url)
+                await db.products.insert_one(product)
+                results.append(product)
+                logging.info("Stored product %s", product.get("title"))
+            except Exception as exc:
+                logging.error("Failed to parse %s: %s", url, exc)
+
+    await asyncio.gather(*(parse_and_store(u) for u in urls))
+    return results
+
+
+async def main(category_url: str, mongo_uri: str, out_file: str,
+               link_concurrency: int = 5, product_concurrency: int = 10) -> None:
+    client = AsyncIOMotorClient(mongo_uri)
+    db = client.pulscen
+
+    links = await gather_product_links(category_url, concurrency=link_concurrency)
+    logging.info("Collected %s product links", len(links))
+
+    products = await gather_products(db, links, concurrency=product_concurrency)
+    with open(out_file, "w") as fh:
+        json.dump(products, fh, ensure_ascii=False, indent=2)
+
+    await client.close()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Parse all products from a Pulscen category")
+    parser.add_argument("category_url", help="URL of the parent category")
+    parser.add_argument("-o", "--out", default="products.json",
+                        help="Path to output JSON file")
+    parser.add_argument("-m", "--mongodb", default="mongodb://localhost:27017",
+                        help="MongoDB connection URI")
+    parser.add_argument("-v", "--verbose", action="store_true", help="Verbose logging")
+    parser.add_argument("--link-concurrency", type=int, default=5,
+                        help="Number of concurrent subcategory parsers")
+    parser.add_argument("--product-concurrency", type=int, default=10,
+                        help="Number of concurrent product fetchers")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO if args.verbose else logging.WARNING,
+                        format="%(levelname)s:%(message)s")
+
+    asyncio.run(main(args.category_url, args.mongodb, args.out,
+                     link_concurrency=args.link_concurrency,
+                     product_concurrency=args.product_concurrency))

--- a/parse_product_links.py
+++ b/parse_product_links.py
@@ -1,0 +1,86 @@
+import asyncio
+import json
+import logging
+from dataclasses import dataclass, asdict
+from typing import List
+from urllib.parse import urljoin
+
+import aiohttp
+from bs4 import BeautifulSoup
+
+
+@dataclass
+class ProductLink:
+    title: str
+    url: str
+
+
+async def fetch_html(url: str) -> str:
+    headers = {
+        "User-Agent": (
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) "
+            "Chrome/116.0.0.0 Safari/537.36"
+        )
+    }
+    async with aiohttp.ClientSession(headers=headers, trust_env=True) as session:
+        logging.info("Fetching %s", url)
+        async with session.get(url) as response:
+            response.raise_for_status()
+            logging.info("Received HTTP %s", response.status)
+            return await response.text()
+
+
+def parse_links(html: str, base_url: str) -> List[ProductLink]:
+    soup = BeautifulSoup(html, "html.parser")
+    links: List[ProductLink] = []
+    for container in soup.select('.product-listing__product-title a'):
+        href = container.get("href")
+        title = container.get_text(strip=True)
+        if href:
+            links.append(ProductLink(title=title, url=urljoin(base_url, href)))
+    return links
+
+
+def find_next_page(html: str, current_url: str) -> str | None:
+    soup = BeautifulSoup(html, "html.parser")
+    next_link = soup.select_one('a[rel="next"]')
+    if next_link and next_link.get('href'):
+        return urljoin(current_url, next_link['href'])
+    return None
+
+
+async def parse(url: str) -> List[dict]:
+    page_url = url
+    results: List[ProductLink] = []
+
+    while page_url:
+        html = await fetch_html(page_url)
+        links = parse_links(html, url)
+        logging.info("Found %s products on %s", len(links), page_url)
+        results.extend(links)
+
+        next_page = find_next_page(html, page_url)
+        if next_page and next_page != page_url:
+            page_url = next_page
+        else:
+            break
+
+    return [asdict(link) for link in results]
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Parse product links from a Pulscen subcategory page"
+    )
+    parser.add_argument("url", help="URL of the subcategory page")
+    parser.add_argument("-v", "--verbose", action="store_true", help="Enable verbose logging")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO if args.verbose else logging.WARNING,
+                        format="%(levelname)s:%(message)s")
+
+    data = asyncio.run(parse(args.url))
+    print(json.dumps(data, ensure_ascii=False, indent=2))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 aiohttp
 beautifulsoup4
+motor


### PR DESCRIPTION
## Summary
- add a new script `parse_product_links.py` to parse product links from a subcategory with pagination support
- document the new script in README
- add an async scraper (`parse_all_products.py`) to collect all products from subcategories and save them to MongoDB and JSON
- add `motor` to requirements

## Testing
- `python -m py_compile parse_categories.py parse_product.py parse_product_links.py parse_all_products.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_68842d86f1cc8329a0470c91f8520dff