### PR TITLE
Stop parsing after empty product page

### DIFF
--- a/parse_product_links.py
+++ b/parse_product_links.py
@@ -70,6 +70,9 @@ async def parse(url: str) -> List[dict]:
 
         links = parse_links(html, url)
         logging.info("Found %s products on %s", len(links), final_url)
+        if not links:
+            logging.info("No products found, stopping at %s", final_url)
+            break
         results.extend(links)
 
         page_num += 1


### PR DESCRIPTION
## Summary
- ensure pagination stops when a page contains no products

## Testing
- `python -m py_compile parse_product_links.py parse_categories.py parse_product.py parse_all_products.py`
- `pip install -r requirements.txt`
- `python parse_product_links.py https://nsk.pulscen.ru/price/1901-nastolnye-kompjutery -v | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_688432656db48329ae17fae3386dba4e