### PR TITLE
Fix invalid await when closing MongoDB client

### DIFF
--- a/parse_all_products.py
+++ b/parse_all_products.py
@@ -60,7 +60,10 @@ async def main(category_url: str, mongo_uri: str, out_file: str,
     with open(out_file, "w") as fh:
         json.dump(products, fh, ensure_ascii=False, indent=2)
 
-    await client.close()
+    # AsyncIOMotorClient.close() is a regular method and doesn't return a
+    # coroutine, so calling it via "await" results in a TypeError. Simply
+    # invoke the method without awaiting to properly close the connection.
+    client.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- remove invalid `await` when closing the Motor client

## Testing
- `python -m py_compile parse_all_products.py parse_product.py parse_product_links.py parse_categories.py`


------
https://chatgpt.com/codex/tasks/task_e_6884332fced48329b696dd352cd586d3