### PR TITLE
Handle optional fields in parsed products

### DIFF
--- a/parse_product.py
+++ b/parse_product.py
@@ -281,7 +281,20 @@ async def parse(url: str) -> dict:
     html = await fetch_html(url)
     product = parse_product(html)
     logging.info("Parsed product: %s", product.title)
-    return asdict(product)
+    def clean(obj):
+        if isinstance(obj, dict):
+            return {
+                k: clean(v)
+                for k, v in obj.items()
+                if v not in (None, [], {})
+            }
+        if isinstance(obj, list):
+            cleaned_list = [clean(item) for item in obj]
+            return [item for item in cleaned_list if item not in (None, [], {})]
+        return obj
+
+    raw = asdict(product)
+    return clean(raw)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- avoid storing fields that are missing when parsing a product

## Testing
- `python -m py_compile parse_product.py`
- `python -m py_compile parse_categories.py parse_product_links.py parse_all_products.py`


------
https://chatgpt.com/codex/tasks/task_e_6884348e8a24832984048e0e9db2bd85