### PR TITLE
Fix JSON dump for products

### DIFF
--- a/parse_all_products.py
+++ b/parse_all_products.py
@@ -58,7 +58,7 @@ async def main(category_url: str, mongo_uri: str, out_file: str,
 
     products = await gather_products(db, links, concurrency=product_concurrency)
     with open(out_file, "w") as fh:
-        json.dump(products, fh, ensure_ascii=False, indent=2)
+        json.dump(products, fh, ensure_ascii=False, indent=2, default=str)
 
     # AsyncIOMotorClient.close() is a regular method and doesn't return a
     # coroutine, so calling it via "await" results in a TypeError. Simply


### PR DESCRIPTION
## Summary
- handle MongoDB ObjectId when writing product list to JSON

## Testing
- `python -m py_compile parse_all_products.py parse_product_links.py parse_categories.py parse_product.py`


------
https://chatgpt.com/codex/tasks/task_e_688435c7fd1c83298f9f8912148db337