### PR TITLE
Fix subcategory fetching without block detection

### DIFF
--- a/parse_categories.py
+++ b/parse_categories.py
@@ -5,9 +5,8 @@ from dataclasses import dataclass, asdict
 from typing import List
 from urllib.parse import urljoin
 
+import aiohttp
 from bs4 import BeautifulSoup
-
-from utils import fetch_html_with_retries
 
 
 @dataclass
@@ -17,8 +16,19 @@ class Subcategory:
 
 
 async def fetch_html(url: str) -> str:
-    html, _ = await fetch_html_with_retries(url)
-    return html
+    headers = {
+        "User-Agent": (
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) "
+            "Chrome/116.0.0.0 Safari/537.36"
+        )
+    }
+    async with aiohttp.ClientSession(headers=headers, trust_env=True) as session:
+        logging.info("Fetching %s", url)
+        async with session.get(url) as response:
+            response.raise_for_status()
+            logging.info("Received HTTP %s", response.status)
+            return await response.text()
 
 
 def parse_subcategories(html: str, base_url: str) -> List[Subcategory]:


### PR DESCRIPTION
## Summary
- revert subcategory fetching to direct aiohttp session without block detection

## Testing
- `python -m py_compile *.py`
- `python parse_categories.py https://nsk.pulscen.ru/price/computer -v | head`

------
https://chatgpt.com/codex/tasks/task_e_6884a11ad4a08329a57cae9a253a3233