### PR TITLE
Refine block detection logic

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -4,8 +4,16 @@ from typing import Tuple
 
 import aiohttp
 
-# Simple keywords that might indicate the site blocked us with a captcha
-BLOCK_PATTERNS = ["captcha", "робот", "доступ ограничен"]
+# Substrings that may indicate the site blocked us.
+# The generic word "captcha" was previously used but it also appears in
+# legitimate page markup (e.g. "SmartCaptcha" footer) causing false
+# positives. We now rely on more specific phrases likely present on a
+# block page.
+BLOCK_PATTERNS = [
+    "не робот",
+    "доступ ограничен",
+    "слишком много запросов",
+]
 
 async def fetch_html_with_retries(url: str, *, allow_redirects: bool = True, retries: int = 3) -> Tuple[str, str]:
     """Fetch a URL with retries and basic spam-block detection."""


### PR DESCRIPTION
## Summary
- tweak the detection keywords to avoid false positives when pages contain SmartCaptcha

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_6884a3204f8883298ac603ea49db1215