### PR TITLE
Add support for anti‑bot RBPCS cookie

### DIFF
--- a/parse_categories.py
+++ b/parse_categories.py
@@ -5,8 +5,8 @@ from dataclasses import dataclass, asdict
 from typing import List
 from urllib.parse import urljoin
 
-import aiohttp
 from bs4 import BeautifulSoup
+from utils import fetch_html_with_retries
 
 
 @dataclass
@@ -16,19 +16,8 @@ class Subcategory:
 
 
 async def fetch_html(url: str) -> str:
-    headers = {
-        "User-Agent": (
-            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
-            "AppleWebKit/537.36 (KHTML, like Gecko) "
-            "Chrome/116.0.0.0 Safari/537.36"
-        )
-    }
-    async with aiohttp.ClientSession(headers=headers, trust_env=True) as session:
-        logging.info("Fetching %s", url)
-        async with session.get(url) as response:
-            response.raise_for_status()
-            logging.info("Received HTTP %s", response.status)
-            return await response.text()
+    html, _ = await fetch_html_with_retries(url)
+    return html
 
 
 def parse_subcategories(html: str, base_url: str) -> List[Subcategory]:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 aiohttp
 beautifulsoup4
 motor
+pycryptodome

--- a/utils.py
+++ b/utils.py
@@ -1,8 +1,10 @@
 import asyncio
 import logging
+import re
 from typing import Tuple
 
 import aiohttp
+from Crypto.Cipher import AES
 
 # Substrings that may indicate the site blocked us.
 # The generic word "captcha" was previously used but it also appears in
@@ -15,7 +17,58 @@ BLOCK_PATTERNS = [
     "слишком много запросов",
 ]
 
-async def fetch_html_with_retries(url: str, *, allow_redirects: bool = True, retries: int = 3) -> Tuple[str, str]:
+def _solve_rbpcs_cookie(html: str) -> str | None:
+    """Extract and decrypt RBPCS cookie from anti-bot page."""
+    m = re.search(
+        r'a=toNumbers\("([0-9a-f]+)"\).*?'
+        r'b=toNumbers\("([0-9a-f]+)"\).*?'
+        r'c=toNumbers\("([0-9a-f]+)"\)',
+        html,
+        re.I | re.S,
+    )
+    if not m:
+        return None
+    try:
+        key, iv, data = (bytes.fromhex(x) for x in m.groups())
+        cipher = AES.new(key, AES.MODE_CBC, iv)
+        return cipher.decrypt(data).hex()
+    except Exception as exc:  # pragma: no cover - crypto errors unexpected
+        logging.warning("Failed to decrypt RBPCS cookie: %s", exc)
+        return None
+
+
+async def _fetch_with_session(
+    session: aiohttp.ClientSession,
+    url: str,
+    *,
+    allow_redirects: bool,
+) -> Tuple[str, str]:
+    async with session.get(url, allow_redirects=allow_redirects) as response:
+        response.raise_for_status()
+        html = await response.text()
+        final_url = str(response.url)
+
+    cookie = _solve_rbpcs_cookie(html)
+    if cookie:
+        session.cookie_jar.update_cookies({"RBPCS": cookie}, response_url=url)
+        async with session.get(url, allow_redirects=allow_redirects) as response:
+            response.raise_for_status()
+            html = await response.text()
+            final_url = str(response.url)
+
+    lowered = html.lower()
+    if any(pattern in lowered for pattern in BLOCK_PATTERNS):
+        raise RuntimeError("Blocked or captcha detected")
+
+    return html, final_url
+
+
+async def fetch_html_with_retries(
+    url: str,
+    *,
+    allow_redirects: bool = True,
+    retries: int = 3,
+) -> Tuple[str, str]:
     """Fetch a URL with retries and basic spam-block detection."""
     headers = {
         "User-Agent": (
@@ -24,20 +77,22 @@ async def fetch_html_with_retries(url: str, *, allow_redirects: bool = True, ret
             "Chrome/116.0.0.0 Safari/537.36"
         )
     }
+
     for attempt in range(1, retries + 1):
         try:
             async with aiohttp.ClientSession(headers=headers, trust_env=True) as session:
                 logging.info("Fetching %s (attempt %s)", url, attempt)
-                async with session.get(url, allow_redirects=allow_redirects) as response:
-                    response.raise_for_status()
-                    html = await response.text()
-                    final_url = str(response.url)
-                    lowered = html.lower()
-                    if any(pattern in lowered for pattern in BLOCK_PATTERNS):
-                        raise RuntimeError("Blocked or captcha detected")
-                    return html, final_url
+                return await _fetch_with_session(
+                    session, url, allow_redirects=allow_redirects
+                )
         except (aiohttp.ClientError, asyncio.TimeoutError, RuntimeError) as exc:
-            logging.warning("Error fetching %s on attempt %s/%s: %s", url, attempt, retries, exc)
+            logging.warning(
+                "Error fetching %s on attempt %s/%s: %s",
+                url,
+                attempt,
+                retries,
+                exc,
+            )
             if attempt == retries:
                 raise
             await asyncio.sleep(2 * attempt)


### PR DESCRIPTION
## Summary
- add `pycryptodome` requirement
- detect and decrypt RBPCS cookie in `utils.fetch_html_with_retries`
- use the retry logic for category fetching

## Testing
- `python -m py_compile parse_categories.py utils.py parse_product_links.py parse_product.py parse_all_products.py && echo OK`


------
https://chatgpt.com/codex/tasks/task_e_6884a99d62308329b6db28a534865f68