### PR TITLE
Fix cookie jar update

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -50,7 +50,8 @@ async def _fetch_with_session(
 
     cookie = _solve_rbpcs_cookie(html)
     if cookie:
-        session.cookie_jar.update_cookies({"RBPCS": cookie}, response_url=url)
+        from yarl import URL
+        session.cookie_jar.update_cookies({"RBPCS": cookie}, response_url=URL(url))
         async with session.get(url, allow_redirects=allow_redirects) as response:
             response.raise_for_status()
             html = await response.text()


### PR DESCRIPTION
## Summary
- fix aiohttp cookie jar usage with yarl.URL

## Testing
- `python3 parse_categories.py https://nsk.pulscen.ru/price/computer -v | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_6884ab6c6e9083299d0c9137f5924055