### PR TITLE
Improve error handling and logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ JSON-массив с названием и URL каждого найденног
 
 ### Полный сбор товаров
 
-Чтобы собрать все товары из родительской категории, сохранить их в MongoDB и JSON‑файл, запустите `parse_all_products.py`:
+Чтобы собрать все товары из родительской категории, сохранить их в MongoDB и JSONL‑файл, запустите `parse_all_products.py`:
 
 ```bash
-python parse_all_products.py https://nsk.pulscen.ru/price/computer -v -o products.json
+python parse_all_products.py https://nsk.pulscen.ru/price/computer -v -o products.jsonl
 ```
 
-По умолчанию данные сохраняются в базу `pulscen` на `mongodb://localhost:27017` и в файл `products.json`.
+По умолчанию данные сохраняются в базу `pulscen` на `mongodb://localhost:27017` и в файл `products.jsonl`.
 

--- a/parse_categories.py
+++ b/parse_categories.py
@@ -54,7 +54,7 @@ if __name__ == "__main__":
 
     logging.basicConfig(
         level=logging.INFO if args.verbose else logging.WARNING,
-        format="%(levelname)s:%(message)s",
+        format="%(asctime)s %(levelname)s:%(message)s",
     )
 
     data = asyncio.run(parse(args.url))

--- a/parse_product.py
+++ b/parse_product.py
@@ -168,6 +168,9 @@ def parse_product(html: str) -> Product:
     descr_tag = soup.select_one('.product-description')
     description = descr_tag.get_text("\n", strip=True) if descr_tag else None
 
+    if not any([title, description]):
+        raise ValueError("Empty product page")
+
     article = None
     art_tag = soup.select_one('.product-description-list__article-value')
     if art_tag:
@@ -298,8 +301,10 @@ if __name__ == '__main__':
     parser.add_argument('--save-html', help='Path to save raw HTML of the product page')
     args = parser.parse_args()
 
-    logging.basicConfig(level=logging.INFO if args.verbose else logging.WARNING,
-                        format='%(levelname)s:%(message)s')
+    logging.basicConfig(
+        level=logging.INFO if args.verbose else logging.WARNING,
+        format='%(asctime)s %(levelname)s:%(message)s',
+    )
 
     data = asyncio.run(parse(args.url, debug_html_path=args.save_html))
     print(json.dumps(data, ensure_ascii=False, indent=2))

--- a/parse_product_links.py
+++ b/parse_product_links.py
@@ -77,8 +77,10 @@ if __name__ == "__main__":
     parser.add_argument("-v", "--verbose", action="store_true", help="Enable verbose logging")
     args = parser.parse_args()
 
-    logging.basicConfig(level=logging.INFO if args.verbose else logging.WARNING,
-                        format="%(levelname)s:%(message)s")
+    logging.basicConfig(
+        level=logging.INFO if args.verbose else logging.WARNING,
+        format="%(asctime)s %(levelname)s:%(message)s",
+    )
 
     data = asyncio.run(parse(args.url))
     print(json.dumps(data, ensure_ascii=False, indent=2))


### PR DESCRIPTION
## Summary
- manage MongoDB connection via an async context manager
- store products as JSONL for safer writes
- handle parse/store errors separately
- add basic validation to parsed product pages
- show timestamps in logs
- update README for JSONL output

## Testing
- `python -m py_compile *.py`
- `python parse_all_products.py --help | head -n 20`
- `python parse_product.py --help | head -n 20`
- `python parse_product_links.py --help | head -n 20`
- `python parse_categories.py --help | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_688b5c80a2448329960bc8950055ca2d