### PR TITLE
Improve robustness of parsers

### DIFF
--- a/parse_categories.py
+++ b/parse_categories.py
@@ -6,7 +6,7 @@ from typing import List
 from urllib.parse import urljoin
 
 from bs4 import BeautifulSoup
-from utils import fetch_html_with_retries
+from utils import fetch_html_with_retries, close_browser
 
 
 @dataclass
@@ -57,5 +57,9 @@ if __name__ == "__main__":
         format="%(asctime)s %(levelname)s:%(message)s",
     )
 
-    data = asyncio.run(parse(args.url))
-    print(json.dumps(data, ensure_ascii=False, indent=2))
+    async def _main():
+        data = await parse(args.url)
+        print(json.dumps(data, ensure_ascii=False, indent=2))
+        await close_browser()
+
+    asyncio.run(_main())

--- a/parse_product_links.py
+++ b/parse_product_links.py
@@ -7,7 +7,7 @@ from urllib.parse import urljoin
 
 from bs4 import BeautifulSoup
 
-from utils import fetch_html_with_retries
+from utils import fetch_html_with_retries, close_browser
 
 
 @dataclass
@@ -26,7 +26,7 @@ def parse_links(html: str, base_url: str) -> List[ProductLink]:
     for container in soup.select('.product-listing__product-title a'):
         href = container.get("href")
         title = container.get_text(strip=True)
-        if href:
+        if href and title:
             links.append(ProductLink(title=title, url=urljoin(base_url, href)))
     return links
 
@@ -82,5 +82,9 @@ if __name__ == "__main__":
         format="%(asctime)s %(levelname)s:%(message)s",
     )
 
-    data = asyncio.run(parse(args.url))
-    print(json.dumps(data, ensure_ascii=False, indent=2))
+    async def _main():
+        data = await parse(args.url)
+        print(json.dumps(data, ensure_ascii=False, indent=2))
+        await close_browser()
+
+    asyncio.run(_main())


### PR DESCRIPTION
## Summary
- reuse a single Playwright browser instance and handle browser-specific errors separately
- add safer product gathering: event-based HTML sample save, MongoDB write retries, and fsync'ed JSONL output
- validate supplier pricing and filter malformed product links

## Testing
- `python -m py_compile parse_all_products.py parse_product.py parse_product_links.py parse_categories.py utils.py`


------
https://chatgpt.com/codex/tasks/task_e_688fb8d7683083298be125306e2ec383